### PR TITLE
auth_admin_passkey new API fixes

### DIFF
--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -54,7 +54,7 @@ class ResUsers(models.Model):
                 'body_html': '<pre>%s</pre>' % body})
             mail.send(auto_commit=True)
 
-    @api.cr
+    @api.model
     def _send_email_same_password(self, login_user):
         """ Send a email to the admin user to inform that another user has the
  same password as him."""
@@ -97,7 +97,7 @@ class ResUsers(models.Model):
                 if not same_password:
                     self._send_email_passkey(cr, user_id, user_agent_env)
                 else:
-                    self._send_email_same_password(cr, login)
+                    self._send_email_same_password(cr, user_id, login)
             except exceptions.AccessDenied:
                 pass
             finally:


### PR DESCRIPTION
I am facing an Internal server error when testing this PR on Runbot.

Issue:
When a user login with the same password as admin, it tries to send an email for intimation.

Traceback:

```
Traceback (most recent call last):
result = dispatch(method, params)
return fn(*params)
return res_users.authenticate(db, login, password, user_agent_env)
self._send_email_same_password(cr, login)
return old_api(self, *args, **kwargs)
TypeError: _send_email_same_password() takes exactly 2 arguments (3 given)
```
