### PR TITLE
[IMP]encode output file

### DIFF
--- a/sql_export/models/sql_export.py
+++ b/sql_export/models/sql_export.py
@@ -45,6 +45,14 @@ class SqlExport(models.Model):
         'Parameters',
         domain=[('model', '=', 'sql.file.wizard')])
 
+    encoding = fields.Selection(
+        [('utf-8', 'utf-8'), ('utf-16', 'utf-16'),
+         ('windows-1252', 'windows-1252'), ('latin1', 'latin1'),
+         ('latin2', 'latin2'), ('big5', 'big5'), ('gb18030', 'gb18030'),
+         ('shift_jis', 'shift_jis'), ('windows-1251', 'windows-1251'),
+         ('koir8_r', 'koir8_r')], string='Encoding', required=True,
+        default='utf-8')
+
     @api.multi
     def export_sql_query(self):
         self.ensure_one()

--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -25,6 +25,7 @@
                 </group>
                 <group name="option" groups="sql_request_abstract.group_sql_request_user">
                     <field name="copy_options"/>
+                    <field name="encoding"/>
                 </group>
                 <group name="request" string="SQL Request" groups="sql_request_abstract.group_sql_request_user">
                     <field name="query" nolabel="1" placeholder="select * from res_partner"/>

--- a/sql_export/wizard/wizard_file.py
+++ b/sql_export/wizard/wizard_file.py
@@ -89,7 +89,8 @@ class SqlFileWizard(models.TransientModel):
         res = sql_export._execute_sql_request(
             params=variable_dict, mode='stdout',
             copy_options=sql_export.copy_options)
-
+        if self.sql_export_id.encoding:
+            res = res.encode(self.sql_export_id.encoding)
         self.write({
             'binary_file': res,
             'file_name': sql_export.name + '_' + date + '.csv'


### PR DESCRIPTION
I think i would be a good idea to have an option to select the encoding of the output file as it's done in importing:

![image](https://cloud.githubusercontent.com/assets/19620251/23895828/797a8980-08a7-11e7-917c-366592ecd9a4.png)

Furthermore, there's has been reported some issues when exporting csv files with sql_export. It seems that the resulting file is not opening correctly in some windows environments.
