### PR TITLE
Fix apply inheritance specs on views (pre_locate)

### DIFF
--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -41,6 +41,7 @@ class IrUiView(models.Model):
     @api.model
     def apply_inheritance_specs(self, source, specs_tree, pre_locate=lambda s: True):
         for specs, handled_by in self._iter_inheritance_specs(specs_tree):
+            pre_locate(specs)
             source = handled_by(source, specs)
         return source
 


### PR DESCRIPTION
To apply on this PR: https://github.com/OCA/server-tools/pull/1937

Code core apply `pre_locate` before apply inheritance specs:
https://github.com/odoo/odoo/blob/14.0/odoo/tools/template_inheritance.py#L131

To be compatible, I suggest to do the same in this specific behavior.

From my context, it's required when using studio:
https://github.com/odoo/enterprise/blob/14.0/web_studio/models/ir_ui_view.py#L460

Without `pre_locate`, we have an error when activate studio from product variants tree view:

```
Odoo Server Error

Traceback (most recent call last):
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/odoo/src/odoo/http.py", line 683, in dispatch
    result = self._call_function(**self.params)
  File "/odoo/src/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/odoo/src/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/odoo/src/odoo/http.py", line 347, in checked_call
    result = self.endpoint(*a, **kw)
  File "/odoo/src/odoo/http.py", line 912, in __call__
    return self.method(*args, **kw)
  File "/odoo/src/odoo/http.py", line 531, in response_wrap
    response = f(*args, **kw)
  File "/odoo/src/addons/web/controllers/main.py", line 1389, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/odoo/src/addons/web/controllers/main.py", line 1381, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/odoo/src/odoo/api.py", line 392, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/odoo/src/odoo/api.py", line 365, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/odoo/src/odoo/models.py", line 1530, in load_views
    for [v_id, v_type] in views
  File "/odoo/src/odoo/models.py", line 1530, in <dictcomp>
    for [v_id, v_type] in views
  File "/odoo/src/addons/web/models/models.py", line 220, in fields_view_get
    r = super().fields_view_get(view_id, view_type, toolbar, submenu)
  File "/odoo/src/odoo/models.py", line 1611, in fields_view_get
    result = self._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
  File "/odoo/src/odoo/models.py", line 1572, in _fields_view_get
    root_view = View.browse(view_id).read_combined(['id', 'name', 'field_parent', 'type', 'model', 'arch'])
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 809, in read_combined
    arch = root.apply_view_inheritance(arch_tree, self.model)
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 750, in apply_view_inheritance
    return self._apply_view_inheritance(source, inherit_tree)
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 758, in _apply_view_inheritance
    source = view.apply_inheritance_specs(source, arch_tree)
  File "/odoo/external-src/enterprise/web_studio/models/ir_ui_view.py", line 461, in apply_inheritance_specs
    pre_locate=pre_locate)
  File "/odoo/external-src/server-tools/base_view_inheritance_extension/models/ir_ui_view.py", line 44, in apply_inheritance_specs
    source = handled_by(source, specs)
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 735, in apply_inheritance_specs
    self.handle_view_error(str(e))
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 673, in handle_view_error
    raise ValueError(formatted_message).with_traceback(from_traceback) from from_exception
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: L'élément '<header studio-view-group-ids="49">' ne peut être localisé dans la vue parente

View name: product.template_procurement
Error context:
 view: ir.ui.view(1184,)
 xmlid: stock.product_template_form_view_procurement_button
 view.model: product.template
 view.parent: ir.ui.view(539,)
```