### PR TITLE
[IMP] attachment_queue : Add possibility to reschedule multiple attac…

### DIFF
--- a/attachment_queue/__init__.py
+++ b/attachment_queue/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/attachment_queue/__manifest__.py
+++ b/attachment_queue/__manifest__.py
@@ -16,6 +16,8 @@
         "security/ir.model.access.csv",
         "data/mail_template.xml",
         "data/queue_job_channel.xml",
+        "wizards/attachement_queue_reschedule.xml",
     ],
+    "demo": ["demo/attachment_queue.xml"],
     "installable": True,
 }

--- a/attachment_queue/data/mail_template.xml
+++ b/attachment_queue/data/mail_template.xml
@@ -2,9 +2,9 @@
 <odoo noupdate="1">
 
         <record id="attachment_failure_notification" model="mail.template">
-            <field name="email_to">${object.failure_emails}</field>
+            <field name="email_to">{{object.failure_emails}}</field>
             <field name="name">Attachment Failure notification</field>
-            <field name="subject">The attachment ${object.name} has failed</field>
+            <field name="subject">The attachment {{object.name}} has failed</field>
             <field name="model_id" ref="attachment_queue.model_attachment_queue" />
             <field
             name="body_html"

--- a/attachment_queue/data/queue_job_channel.xml
+++ b/attachment_queue/data/queue_job_channel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
     <record id="attachment_queue_job_channel" model="queue.job.channel">
-        <field name="name">Attachment queues</field>
+        <field name="name">attachment_queue</field>
         <field name="parent_id" ref="queue_job.channel_root" />
     </record>
 </odoo>

--- a/attachment_queue/demo/attachment_queue.xml
+++ b/attachment_queue/demo/attachment_queue.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="dummy_attachment_queue" model="attachment.queue">
+        <field name="name">Dummy file Used for unitests</field>
+    </record>
+</odoo>

--- a/attachment_queue/security/ir.model.access.csv
+++ b/attachment_queue/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_attachment_queue_user,attachment.queue.user,model_attachment_queue,,1,0,0,0
 access_attachment_queue_manager,attachment.queue.manager,model_attachment_queue,base.group_no_one,1,1,1,1
+access_attachment_reschedule_wizard,Attachment Queue Reschedule,attachment_queue.model_attachment_queue_reschedule,base.group_no_one,1,1,1,1

--- a/attachment_queue/tests/test_attachment_queue.py
+++ b/attachment_queue/tests/test_attachment_queue.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from odoo_test_helper import FakeModelLoader
 
+from odoo import registry
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
@@ -53,21 +54,41 @@ class TestAttachmentBaseQueue(TransactionCase):
         with trap_jobs() as trap:
             self._create_dummy_attachment()
             trap.assert_enqueued_job(
-                self.env["attachment.queue"].run,
+                self.env["attachment.queue"].run_as_job,
             )
 
     def test_aq_locked_job(self):
         """If an attachment is already running, and a job tries to run it, retry later"""
-        with self.assertRaises(RetryableJobError):
-            self._create_dummy_attachment({"running_lock": True}, no_job=True)
+        attachment = self.env.ref("attachment_queue.dummy_attachment_queue")
+        with registry(self.env.cr.dbname).cursor() as new_cr:
+            new_cr.execute(
+                """
+                SELECT id
+                FROM attachment_queue
+                WHERE id  = %s
+                FOR UPDATE NOWAIT
+            """,
+                (attachment.id,),
+            )
+            with self.assertRaises(RetryableJobError):
+                attachment.run_as_job()
 
     def test_aq_locked_button(self):
         """If an attachment is already running, and a user tries to run it manually,
         raise error window"""
-        attachment = self._create_dummy_attachment(no_job=True)
-        attachment.running_lock = True
-        with self.assertRaises(UserError):
-            attachment.button_manual_run()
+        attachment = self.env.ref("attachment_queue.dummy_attachment_queue")
+        with registry(self.env.cr.dbname).cursor() as new_cr:
+            new_cr.execute(
+                """
+                SELECT id
+                FROM attachment_queue
+                WHERE id  = %s
+                FOR UPDATE NOWAIT
+            """,
+                (attachment.id,),
+            )
+            with self.assertRaises(UserError):
+                attachment.button_manual_run()
 
     def test_run_ok(self):
         """Attachment queue should have correct state and result"""
@@ -102,6 +123,10 @@ class TestAttachmentBaseQueue(TransactionCase):
             self._create_dummy_attachment(no_job=True)
             partners_after = len(self.env["res.partner"].search([]))
             self.assertEqual(partners_after, partners_initial)
+            failure_email = self.env["mail.mail"].search(
+                [("subject", "ilike", "dummy_aq.doc")]
+            )
+            self.assertEqual(failure_email.email_to, "test@test.com")
 
     def test_set_done(self):
         """Test set_done manually"""
@@ -109,3 +134,14 @@ class TestAttachmentBaseQueue(TransactionCase):
         self.assertEqual(attachment.state, "pending")
         attachment.set_done()
         self.assertEqual(attachment.state, "done")
+
+    def test_reschedule_wizard(self):
+        attachment = self.env.ref("attachment_queue.dummy_attachment_queue")
+        attachment.write({"state": "failed"})
+        wizard = (
+            self.env["attachment.queue.reschedule"]
+            .with_context(active_model="attachment.queue", active_ids=attachment.ids)
+            .create({})
+        )
+        wizard.reschedule()
+        self.assertEqual(attachment.state, "pending")

--- a/attachment_queue/tests/test_models.py
+++ b/attachment_queue/tests/test_models.py
@@ -18,3 +18,6 @@ class AttachmentQueue(models.Model):
     def mock_run_create_partners_and_fail(self):
         self.mock_run_create_partners()
         raise UserError(_("boom"))
+
+    def _get_failure_emails(self):
+        return "test@test.com"

--- a/attachment_queue/views/attachment_queue_view.xml
+++ b/attachment_queue/views/attachment_queue_view.xml
@@ -47,6 +47,7 @@
         <field name="model">attachment.queue</field>
         <field name="arch" type="xml">
             <tree default_order='create_date desc'>
+                <field name="create_date" />
                 <field name="name" />
                 <field name="file_type" />
                 <field name="type" />
@@ -152,7 +153,7 @@
 
     <menuitem
         id="menu_attachment_queue"
-        parent="base.next_id_9"
+        parent="queue_job.menu_queue_job_root"
         sequence="20"
         action="action_attachment_queue"
     />

--- a/attachment_queue/wizards/__init__.py
+++ b/attachment_queue/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import attachement_queue_reschedule

--- a/attachment_queue/wizards/attachement_queue_reschedule.py
+++ b/attachment_queue/wizards/attachement_queue_reschedule.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2020 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo import fields, models
+
+
+class AttachmentQueueReschedule(models.TransientModel):
+    _name = "attachment.queue.reschedule"
+    _description = "Wizard to reschedule a selection of attachments"
+
+    def _default_attachment_ids(self):
+        res = False
+        context = self.env.context
+        if context.get("active_model") == "attachment.queue" and context.get(
+            "active_ids"
+        ):
+            res = context["active_ids"]
+        return res
+
+    attachment_ids = fields.Many2many(
+        comodel_name="attachment.queue",
+        string="Attachments",
+        default=lambda r: r._default_attachment_ids(),
+    )
+
+    def reschedule(self):
+        attachments = self.attachment_ids
+        attachments.button_reschedule()
+        return {"type": "ir.actions.act_window_close"}

--- a/attachment_queue/wizards/attachement_queue_reschedule.xml
+++ b/attachment_queue/wizards/attachement_queue_reschedule.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_reschedule_attachment" model="ir.ui.view">
+        <field name="name">Reschedule Attachments</field>
+        <field name="model">attachment.queue.reschedule</field>
+        <field name="arch" type="xml">
+            <form string="Requeue Attachments">
+                <group string="The selected attachments will be rescheduled.">
+                    <field name="attachment_ids" nolabel="1" colspan="2" />
+                </group>
+                <footer>
+                    <button
+                        name="reschedule"
+                        string="Reschedule"
+                        type="object"
+                        class="oe_highlight"
+                    />
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_reschedule_attachment" model="ir.actions.act_window">
+        <field name="name">Reschedule Attachment</field>
+        <field name="res_model">attachment.queue.reschedule</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_reschedule_attachment" />
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="attachment_queue.model_attachment_queue" />
+    </record>
+
+</odoo>


### PR DESCRIPTION
…hment at once


@kevinkhao 
Tu peux jeter un oeil pour qu'on merge cela rapidement dans ta PR ?

Refactore de la façon de vérifier qu'on ne joue pas un même attachment en parallèle => On fait un lock sur l'attachment et on évite ainsi de se baser sur le système de conccurent update, qui a plus de chance de créer des soucis en production à mon avis et crée plus de latence (car qui dit conccurent update dit retry automatique, etc)

Ajout de la possibilité de replanifier des attachments en masse

Changement de place du menu => Déplacer dans l'application Queue à côté des jobs.

Changement du nom du channel pour mettre un nom technique

Changement de la manière de passer les attributs aux jobs afin qu'on puisse le customiser par "file type" au besoin.